### PR TITLE
perf: simplify hashObject function

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -484,7 +483,7 @@ export function normalizeAlias(
  * @returns {string} the hash of the object
  */
 export function hashObject(obj: unknown): string {
-  return crypto.createHash("sha256").update(stableHash(obj)).digest("hex");
+  return stableHash(obj);
 }
 
 /**

--- a/tests/__snapshots__/utils.spec.ts.snap
+++ b/tests/__snapshots__/utils.spec.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`utils > test hash object > hash object 1`] = `"c710e218177ae3b76ac1b058d43fbd56c3dc71b48709dc15326862a75b0beec2"`;
+exports[`utils > test hash object > hash object 1`] = `"#d:#e:"f",,c:@1,2,3,,b:"string",a:1,"`;

--- a/tests/__snapshots__/utils.windows.spec.ts.snap
+++ b/tests/__snapshots__/utils.windows.spec.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`utils (Windows) > test hash object > hash object 1`] = `"c710e218177ae3b76ac1b058d43fbd56c3dc71b48709dc15326862a75b0beec2"`;
+exports[`utils (Windows) > test hash object > hash object 1`] = `"#d:#e:"f",,c:@1,2,3,,b:"string",a:1,"`;


### PR DESCRIPTION
We do not need sha256 for the hash.